### PR TITLE
fix: missing doxyqml

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -24,7 +24,7 @@ build() {
   cmake -GNinja \
       -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/\
       -DQML_INSTALL_DIR=lib/qt/qml \
-      -DBUILD_DOCS=ON \
+      -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \
       -DQCH_INSTALL_DESTINATION=share/doc/qt \
       -DCMAKE_INSTALL_LIBDIR=lib \

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Build-Depends:
  pkg-kde-tools,
  libgtest-dev,
  doxygen,
+ doxyqml,
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 


### PR DESCRIPTION
  don't build docs in arch.
  add dependency in debian.