### PR TITLE
fix: wrong install path for plugins

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -22,11 +22,11 @@ build() {
   cd $sourcedir
   version=$(echo $pkgver | awk -F'[+_~-]' '{print $1}')
   cmake -GNinja \
-      -DMKSPECS_INSTALL_DIR=lib/qt/mkspecs/modules/\
-      -DQML_INSTALL_DIR=lib/qt/qml \
+      -DMKSPECS_INSTALL_DIR=lib/qt6/mkspecs/modules/\
+      -DQML_INSTALL_DIR=lib/qt6/qml \
       -DBUILD_DOCS=OFF \
       -DBUILD_EXAMPLES=OFF \
-      -DQCH_INSTALL_DESTINATION=share/doc/qt \
+      -DQCH_INSTALL_DESTINATION=share/doc/qt6 \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_INSTALL_PREFIX=/usr \
       -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
  qml is installed in qt6 directory for qt6.