### PR TITLE
chore: remove dtk-exhibition's desktop in debian

### DIFF
--- a/debian/dtk6-exhibition.install
+++ b/debian/dtk6-exhibition.install
@@ -1,2 +1,1 @@
 usr/lib/*/*/DDeclarative/*
-usr/share/applications/dtk6-exhibition.desktop


### PR DESCRIPTION
  dtk-exhibition is only a tool used by developers.