### PR TITLE
feat: Use normal wrap mode instead of WordWrap for ToolTip.Text

### DIFF
--- a/qt6/src/qml/ToolTip.qml
+++ b/qt6/src/qml/ToolTip.qml
@@ -27,7 +27,7 @@ T.ToolTip {
         verticalAlignment: Text.AlignVCenter
         text: control.text
         font: control.font
-        wrapMode: Text.WordWrap
+        wrapMode: Text.Wrap
         opacity: enabled ? 1.0 : 0.4
         color: control.palette.toolTipText
     }

--- a/src/qml/ToolTip.qml
+++ b/src/qml/ToolTip.qml
@@ -27,7 +27,7 @@ T.ToolTip {
         verticalAlignment: Text.AlignVCenter
         text: control.text
         font: control.font
-        wrapMode: Text.WordWrap
+        wrapMode: Text.Wrap
         opacity: enabled ? 1.0 : 0.4
         color: control.palette.toolTipText
     }


### PR DESCRIPTION
Bug: https://pms.uniontech.com/bug-view-271423.html
Log: Use normal wrap mode instead of WordWrap for ToolTip.Text