### PR TITLE
chore: bump version to 6.0.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+dtk6declarative (6.0.31) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 27 Feb 2025 20:57:44 +0800
+
 dtk6declarative (6.0.30) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkdeclarative


### PR DESCRIPTION
update changelog to 6.0.31

## Summary by Sourcery

Chores:
- Bump version to 6.0.31.