### PR TITLE
chore: bump version to 6.0.32

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dtk6declarative (6.0.32) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 06 Mar 2025 17:38:56 +0800
+
 dtk6declarative (6.0.31) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkdeclarative


### PR DESCRIPTION
update changelog to 6.0.32

## Summary by Sourcery

Chores:
- Update changelog to version 6.0.32.