### PR TITLE
chore: bump version to 6.0.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dtk6declarative (6.0.34) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 17 Apr 2025 21:54:31 +0800
+
 dtk6declarative (6.0.33) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkdeclarative


### PR DESCRIPTION
update changelog to 6.0.34

## Summary by Sourcery

Chores:
- Update project version in the Debian changelog file