### PR TITLE
chore: bump version to 6.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dtk6declarative (6.0.35) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkdeclarative
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 08 May 2025 18:50:44 +0800
+
 dtk6declarative (6.0.34) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkdeclarative


### PR DESCRIPTION
update changelog to 6.0.35

## Summary by Sourcery

Chores:
- Update project version to 6.0.35