### PR TITLE
chore: bump version to 6.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dtk6declarative (6.0.36) unstable; urgency=medium
+
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+  * sync: from linuxdeepin/dtkdeclarative
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Mon, 19 May 2025 17:24:07 +0800
+
 dtk6declarative (6.0.35) unstable; urgency=medium
 
   * sync: from linuxdeepin/dtkdeclarative


### PR DESCRIPTION
update changelog to 6.0.36

## Summary by Sourcery

Bump the Debian package version to 6.0.36 and update its changelog accordingly