### PR TITLE
fix: make version parameter optional in release workflow

### DIFF
--- a/.github/workflows/call-auto-release.yml
+++ b/.github/workflows/call-auto-release.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Release version (e.g., 1.0.0)'
         type: string
-        required: true
+        required: false
       name:
         description: 'The name of the person to release the version'
         type: string


### PR DESCRIPTION
1. Changed the 'version' parameter from required to optional in the
GitHub Actions workflow
2. This provides more flexibility when triggering releases
3. Allows for cases where version might be determined programmatically
or isn't needed
4. Maintains backward compatibility while adding more workflow options

fix: 在发布工作流中将版本参数设为可选

1. 将 GitHub Actions 工作流中的 'version' 参数从必填改为可选
2. 这为触发发布提供了更大的灵活性
3. 允许版本号通过程序确定或不需要版本号的情况
4. 在添加更多工作流选项的同时保持向后兼容性

## Summary by Sourcery

CI:
- Make the version input optional in the GitHub Actions release workflow to allow greater flexibility and programmatic determination