### PR TITLE
fix: adjust scrollbar visibility logic

### DIFF
--- a/qt6/src/qml/ScrollBar.qml
+++ b/qt6/src/qml/ScrollBar.qml
@@ -31,7 +31,7 @@ T.ScrollBar {
         State {
             name: "normal"
             property bool moving: control.active && !control.pressed && !control.hovered
-            when: control.policy === T.ScrollBar.AlwaysOn || ( moving && control.size < 1.0)
+            when: (control.policy === T.ScrollBar.AlwaysOn && !control.hovered && !control.pressed) || (moving && control.size < 1.0)
             PropertyChanges {
                 target: control.contentItem
                 implicitWidth: DS.Style.scrollBar.width


### PR DESCRIPTION
Fixed scrollbar visibility condition to properly handle AlwaysOn policy with hover/pressed states. The previous logic would show scrollbar in AlwaysOn mode even when hovered or pressed, which caused visual inconsistency. Now it only shows when not hovered and not pressed in AlwaysOn mode, while maintaining the original behavior for the moving condition.

修复滚动条可见性逻辑

修复滚动条可见性条件以正确处理 AlwaysOn 策略与悬停/按下状态。之前的逻辑
会在 AlwaysOn 模式下即使悬停或按下时也显示滚动条，这导致视觉不一致。现在
在 AlwaysOn 模式下仅在未悬停且未按下时显示，同时保持移动条件的原始行为。

Pms: BUG-332031

## Summary by Sourcery

Adjust scrollbar visibility logic to properly handle the AlwaysOn policy by only showing the scrollbar when not hovered or pressed, while preserving the original moving behavior.

Bug Fixes:
- Fix scrollbar AlwaysOn policy to hide the scrollbar when hovered or pressed
- Preserve existing moving-based visibility for scrollbars under the size threshold