### PR TITLE
fix(slider): adjust path calculation for handle alignment

### DIFF
--- a/qt6/src/qml/Slider.qml
+++ b/qt6/src/qml/Slider.qml
@@ -99,7 +99,7 @@ T.Slider {
                         startX: control.horizontal ? 0 : sliderGroove.width / 2
                         startY: control.horizontal ? sliderGroove.height / 2 : sliderGroove.height
                         PathLine {
-                            x: control.horizontal ? control.handle.x : sliderGroove.width / 2
+                            x: control.horizontal ? (control.handleType < 0 ? control.handle.x + control.handle.width : control.handle.x) : sliderGroove.width / 2
                             y: control.horizontal ? sliderGroove.height / 2 : control.handle.y + control.handle.height / 2
                         }
                     }


### PR DESCRIPTION
When handleType is less than 0, the x-coordinate calculation now includes the handle width offset to correct the visual alignment of the slider path.

log: adjust path calculation for handle alignment
pms: BUG-349793