### PR TITLE
fix: Handle exceptions when hovering over up/down arrows

### DIFF
--- a/qt6/src/qml/ArrowListView.qml
+++ b/qt6/src/qml/ArrowListView.qml
@@ -27,6 +27,7 @@ FocusScope {
             Layout.fillWidth: true
             Layout.preferredHeight: height
             view: itemsView
+            stepSize: control.itemHeight
             direction: P.ArrowListViewButton.UpButton
         }
 
@@ -82,6 +83,7 @@ FocusScope {
             Layout.fillWidth: true
             Layout.preferredHeight: height
             view: itemsView
+            stepSize: control.itemHeight
             direction: P.ArrowListViewButton.DownButton
         }
     }

--- a/qt6/src/qml/private/ArrowListViewButton.qml
+++ b/qt6/src/qml/private/ArrowListViewButton.qml
@@ -14,6 +14,7 @@ Loader {
 
     required property Item view
     property int direction
+    property int stepSize: DS.Style.arrowListView.itemHeight
     active: view.interactive
 
     sourceComponent: ActionButton {
@@ -26,17 +27,21 @@ Loader {
         icon.width: DS.Style.arrowListView.stepButtonIconSize.width
         icon.height: DS.Style.arrowListView.stepButtonIconSize.height
 
-        // Unified scroll operation function
         function performScroll() {
-            direction === ArrowListViewButton.UpButton ? view.decrementCurrentIndex() 
-                                                       : view.incrementCurrentIndex()
+            if (!view)
+                return
+            var maxY = Math.max(0, view.contentHeight - view.height)
+            if (maxY <= 0)
+                return
+            var step = Math.max(1, stepSize)
+            var nextY = direction === ArrowListViewButton.UpButton ? (view.contentY - step)
+                                                                   : (view.contentY + step)
+            view.contentY = Math.max(0, Math.min(maxY, nextY))
         }
 
-        // Auto-scroll control properties using state machine approach
         property bool shouldAutoScroll: hovered && enabled
         property bool delayCompleted: false
 
-        // Timer for initial delay before starting hover scroll
         Timer {
             id: initialDelayTimer
             interval: 300
@@ -45,7 +50,6 @@ Loader {
             onTriggered: delayCompleted = true
         }
 
-        // Timer for continuous hover scrolling
         Timer {
             id: hoverScrollTimer
             interval: 100
@@ -53,12 +57,12 @@ Loader {
             running: shouldAutoScroll && delayCompleted
             onTriggered: performScroll()
         }
-                
-        // Reset state when auto-scroll should stop
+
         onShouldAutoScrollChanged: {
-            if (!shouldAutoScroll) {
+            if (!shouldAutoScroll)
                 delayCompleted = false
-            }
         }
+
+        onClicked: performScroll()
     }
 }


### PR DESCRIPTION
log: Modify arrow scrolling logic to adjust only contentY (scroll by step size in pixels), completely bypassing currentIndex. Also add single-step scrolling when clicking arrows.

pms: bug-335545

## Summary by Sourcery

Adjust arrow list view buttons to scroll by pixel-based content offsets instead of index changes and support single-step scrolling on click.

Bug Fixes:
- Prevent exceptions when hovering over arrow list view buttons by guarding scroll operations when the view is unavailable or not scrollable.

Enhancements:
- Introduce configurable step size for arrow list view button scrolling based on item height.
- Unify hover and click behavior so both trigger the same bounded scroll operation.